### PR TITLE
Use access token instead of user id and password

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,15 +59,13 @@ Instantiate the class as follows.
 
 Aside from the main methods that return the data, all methods support chaining.
 
-To use the Reporter, you will need the user id and password for your iTunes Connect account, you set them as follows.
+To use the Reporter, you will need the an access token for your iTunes Connect account. This is obtained from the [iTunes Connect Sales and Trends screen](https://reportingitc2.apple.com/reports.html), as described in the [Reporter documentation](https://help.apple.com/itc/appsreporterguide/#/apd2f1f1cfa3). Set the access token as follows.
 
-	$Reporter->setUserId('me@example.com');
-	$Reporter->setPassword('securePassword!');
+	$Reporter->setAccessToken('12345678-1234-abcd-abcd-12345678abcd');
 
 There are also "getter" methods to retrieve the currently set data.
 
-	$Reporter->getUserId();
-	$Reporter->getPassword();
+	$Reporter->getAccessToken();
 
 Before progressing any further with this package, it will be worth while reviewing Apples Documentation at [https://help.apple.com/itc/appsreporterguide/](https://help.apple.com/itc/appsreporterguide/).
 
@@ -340,8 +338,7 @@ If you've run a method to get a report or account / vendor numbers to find you a
         new \GuzzleHttp\Client
     );
 
-    $Reporter->setUserId('user@email.com')
-        ->setPassword('password');
+    $Reporter->setAccessToken('12345678-1234-abcd-abcd-12345678abcd');
 
     $failedAccounts = $Reporter->getSalesAccount();
 

--- a/src/Reporter.php
+++ b/src/Reporter.php
@@ -222,7 +222,7 @@ class Reporter
         }
 
         $json = [
-            'access_token' => $this->access_token,
+            'accesstoken' => $this->access_token,
             'version'      => self::VERSION,
             'mode'         => self::MODE,
             'account'      => (string)$this->account

--- a/src/Reporter.php
+++ b/src/Reporter.php
@@ -10,11 +10,12 @@ class Reporter
     const
         SALESURL   = 'https://reportingitc-reporter.apple.com/reportservice/sales/v1',
         FINANCEURL = 'https://reportingitc-reporter.apple.com/reportservice/finance/v1',
-        VERSION    = '2.0',
+        VERSION    = '2.1',
         MODE       = 'Robot.XML';
 
     protected $userid;
     protected $password;
+    protected $access_key;
     protected $account = 'None';
     protected $Guzzle;
     protected $responses = [
@@ -221,11 +222,10 @@ class Reporter
         }
 
         $json = [
-            'userid'   => $this->userid,
-            'password' => $this->password,
-            'version'  => self::VERSION,
-            'mode'     => self::MODE,
-            'account'  => (string)$this->account
+            'access_key' =>	$this->access_key,
+            'version'    => self::VERSION,
+            'mode'       => self::MODE,
+            'account'    => (string)$this->account
         ];
 
         // build up the action and parameters we actually want to perform
@@ -314,60 +314,6 @@ class Reporter
     }
 
     /**
-     * set the user id
-     *
-     * @param string $userid
-     * @return Reporter $this
-     * @throws \InvalidArgumentException
-     */
-    public function setUserId($userid)
-    {
-        if (empty($userid) || ! is_string($userid)) {
-            throw new \InvalidArgumentException('Argument passed to Reporter::setUser was not a string');
-        }
-
-        $this->userid = $userid;
-        return $this;
-    }
-
-    /**
-     * return the user id currently set
-     *
-     * @return string $userid
-     */
-    public function getUserId()
-    {
-        return $this->userid;
-    }
-
-    /**
-     * set the password
-     *
-     * @param string $password
-     * @return Reporter $this
-     * @throws \InvalidArgumentException
-     */
-    public function setPassword($password)
-    {
-        if (empty($password) || ! is_string($password)) {
-            throw new \InvalidArgumentException('Argument passed to Reporter::setPassword was not a string');
-        }
-
-        $this->password = $password;
-        return $this;
-    }
-
-    /**
-     * return the password currently set
-     *
-     * @return string $password
-     */
-    public function getPassword()
-    {
-        return $this->password;
-    }
-
-    /**
      * set the account num to use
      *
      * @param string $account
@@ -394,5 +340,32 @@ class Reporter
     public function getAccountNum()
     {
         return $this->account;
+    }
+
+    /**
+     * set the access key to use
+     *
+     * @param string $access_key
+     * @return Reporter $this
+     * @throws \InvalidArgumentException
+     */
+    public function setAccessKey($access_key)
+    {
+        if (empty($access_key) || ! is_string($access_key)) {
+            throw new \InvalidArgumentException('Argument passed to Reporter::setAccessKey was not a string');
+        }
+
+        $this->access_key = $access_key;
+        return $this;
+    }
+
+    /**
+     * return the access key currently set
+     *
+     * @return string $access_key
+     */
+    public function getAccessKey()
+    {
+        return $this->access_key;
     }
 }

--- a/src/Reporter.php
+++ b/src/Reporter.php
@@ -15,7 +15,7 @@ class Reporter
 
     protected $userid;
     protected $password;
-    protected $access_key;
+    protected $access_token;
     protected $account = 'None';
     protected $Guzzle;
     protected $responses = [
@@ -222,10 +222,10 @@ class Reporter
         }
 
         $json = [
-            'access_key' =>	$this->access_key,
-            'version'    => self::VERSION,
-            'mode'       => self::MODE,
-            'account'    => (string)$this->account
+            'access_token' => $this->access_token,
+            'version'      => self::VERSION,
+            'mode'         => self::MODE,
+            'account'      => (string)$this->account
         ];
 
         // build up the action and parameters we actually want to perform
@@ -345,27 +345,27 @@ class Reporter
     /**
      * set the access key to use
      *
-     * @param string $access_key
+     * @param string $access_token
      * @return Reporter $this
      * @throws \InvalidArgumentException
      */
-    public function setAccessKey($access_key)
+    public function setAccessToken($access_token)
     {
-        if (empty($access_key) || ! is_string($access_key)) {
-            throw new \InvalidArgumentException('Argument passed to Reporter::setAccessKey was not a string');
+        if (empty($access_token) || ! is_string($access_token)) {
+            throw new \InvalidArgumentException('Argument passed to Reporter::setAccessToken was not a string');
         }
 
-        $this->access_key = $access_key;
+        $this->access_token = $access_token;
         return $this;
     }
 
     /**
      * return the access key currently set
      *
-     * @return string $access_key
+     * @return string $access_token
      */
-    public function getAccessKey()
+    public function getAccessToken()
     {
-        return $this->access_key;
+        return $this->access_token;
     }
 }

--- a/tests/ReporterTest.php
+++ b/tests/ReporterTest.php
@@ -17,7 +17,7 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testCanSetAndGetUserId()
+    public function testCanSetAndGetAccessToken()
     {
         $Reporter = new Reporter(
             new Client
@@ -25,16 +25,16 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(
             'Snscripts\ITCReporter\Reporter',
-            $Reporter->setUserId('me@example.com')
+            $Reporter->setAccessToken('12345678-1234-abcd-abcd-12345678abcd')
         );
 
         $this->assertSame(
-            'me@example.com',
-            $Reporter->getUserId()
+            '12345678-1234-abcd-abcd-12345678abcd',
+            $Reporter->getAccessToken()
         );
     }
 
-    public function testSetUserIdThrowsExceptionWithInvalidData()
+    public function testSetAccessTokenThrowsExceptionWithInvalidData()
     {
         $this->setExpectedException('InvalidArgumentException');
 
@@ -42,41 +42,10 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
             new Client
         );
 
-        $Reporter->setUserId(123);
-        $Reporter->setUserId([]);
-        $Reporter->setUserId(new \StdClass);
-        $Reporter->setUserId('');
-    }
-
-    public function testCanSetAndGetPassword()
-    {
-        $Reporter = new Reporter(
-            new Client
-        );
-
-        $this->assertInstanceOf(
-            'Snscripts\ITCReporter\Reporter',
-            $Reporter->setPassword('?S3cureP455Word!')
-        );
-
-        $this->assertSame(
-            '?S3cureP455Word!',
-            $Reporter->getPassword()
-        );
-    }
-
-    public function testSetPasswordThrowsExceptionWithInvalidData()
-    {
-        $this->setExpectedException('InvalidArgumentException');
-
-        $Reporter = new Reporter(
-            new Client
-        );
-
-        $Reporter->setPassword(123);
-        $Reporter->setPassword([]);
-        $Reporter->setPassword(new \StdClass);
-        $Reporter->setPassword('');
+        $Reporter->setAccessToken(123);
+        $Reporter->setAccessToken([]);
+        $Reporter->setAccessToken(new \StdClass);
+        $Reporter->setAccessToken('');
     }
 
     public function testCanSetAndGetAccount()
@@ -115,11 +84,10 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
             new Client
         );
 
-        $Reporter->setUserId('me@example.com')
-            ->setPassword('mypassword!');
+        $Reporter->setAccessToken('12345678-1234-abcd-abcd-12345678abcd');
 
         $this->assertSame(
-            '{"userid":"me@example.com","password":"mypassword!","version":"2.0","mode":"Robot.XML","account":"None","queryInput":"[p=Reporter.properties, Sales.getAccounts]"}',
+            '{"accesstoken":"12345678-1234-abcd-abcd-12345678abcd","version":"2.1","mode":"Robot.XML","account":"None","queryInput":"[p=Reporter.properties, Sales.getAccounts]"}',
             $Reporter->buildJsonRequest('Sales.getAccounts')
         );
     }
@@ -130,12 +98,11 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
             new Client
         );
 
-        $Reporter->setUserId('me@example.com')
-            ->setPassword('mypassword!')
+        $Reporter->setAccessToken('12345678-1234-abcd-abcd-12345678abcd')
             ->setAccountNum(1234567);
 
         $this->assertSame(
-            '{"userid":"me@example.com","password":"mypassword!","version":"2.0","mode":"Robot.XML","account":"1234567","queryInput":"[p=Reporter.properties, Sales.getVendors]"}',
+            '{"accesstoken":"12345678-1234-abcd-abcd-12345678abcd","version":"2.1","mode":"Robot.XML","account":"1234567","queryInput":"[p=Reporter.properties, Sales.getVendors]"}',
             $Reporter->buildJsonRequest('Sales.getVendors')
         );
     }
@@ -146,11 +113,10 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
             new Client
         );
 
-        $Reporter->setUserId('me@example.com')
-            ->setPassword('mypassword!');
+        $Reporter->setAccessToken('12345678-1234-abcd-abcd-12345678abcd');
 
         $this->assertSame(
-            '{"userid":"me@example.com","password":"mypassword!","version":"2.0","mode":"Robot.XML","account":"None","queryInput":"[p=Reporter.properties, Sales.getReport, 12345678,Sales,Summary,Daily,20161020]"}',
+            '{"accesstoken":"12345678-1234-abcd-abcd-12345678abcd","version":"2.1","mode":"Robot.XML","account":"None","queryInput":"[p=Reporter.properties, Sales.getReport, 12345678,Sales,Summary,Daily,20161020]"}',
             $Reporter->buildJsonRequest('Sales.getReport', '12345678', 'Sales', 'Summary', 'Daily', '20161020')
         );
     }
@@ -163,8 +129,7 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
             new Client
         );
 
-        $Reporter->setUserId('me@example.com')
-            ->setPassword('mypassword!')
+        $Reporter->setAccessToken('12345678-1234-abcd-abcd-12345678abcd')
             ->setAccountNum(1234567)
             ->buildJsonRequest();
     }
@@ -237,7 +202,7 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
         $Reporter = new Reporter(
             $GuzzleMock
         );
-        $Reporter->setUserId('me@me.com')->setPassword('123qaz');
+        $Reporter->setAccessToken('12345678-1234-abcd-abcd-12345678abcd');
 
         $Result = $Reporter->performRequest(
             Reporter::SALESURL,
@@ -281,7 +246,7 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
         $Reporter = new Reporter(
             $GuzzleMock
         );
-        $Reporter->setUserId('me@me.com')->setPassword('123qaz');
+        $Reporter->setAccessToken('12345678-1234-abcd-abcd-12345678abcd');
 
         $Result = $Reporter->performRequest(
             Reporter::SALESURL,
@@ -682,7 +647,7 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
         $Reporter = new Reporter(
             $GuzzleMock
         );
-        $Reporter->setUserId('me@me.com')->setPassword('123qaz');
+        $Reporter->setAccessToken('12345678-1234-abcd-abcd-12345678abcd');
 
         $this->assertNull(
             $Reporter->getLastResult()


### PR DESCRIPTION
Apple is removing the ability to access Reporter with an iTunes Connect user id (email) and password. Instead, you must generate a access token from the Sales and Trends area, and use that.

These changes remove user id and password from the itc-reporter package and add support for setting an access token.