### PR TITLE
✨ Upgrade to PHP 8.2 and PHPUnit 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ This is the first PHP Composer based port of the Reporter tool and attempts to m
 
 ITC-Reporter requires the following:
 
-* "php": ">=5.5.0"
-* "guzzlehttp/guzzle": "6.*"
+* "php": ">=8.2.0"
+* "guzzlehttp/guzzle": "7.*"
 * "snscripts/result": "1.0.*"
 
 And the following if you wish to run in dev mode and run tests.
 
-* "phpunit/phpunit": "~4.0"
+* "phpunit/phpunit": "~9.0"
 * "squizlabs/php_codesniffer": "~2.0"
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "6.*",
+        "php": ">=8.2",
+        "guzzlehttp/guzzle": "7.*",
         "snscripts/result": "1.0.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
+        "phpunit/phpunit": "~9.0",
         "squizlabs/php_codesniffer": "~2.0"
     },
     "autoload": {

--- a/src/Reporter.php
+++ b/src/Reporter.php
@@ -1,8 +1,8 @@
 <?php
 namespace Snscripts\ITCReporter;
 
-use GuzzleHttp\ClientInterface;
 use Snscripts\Result\Result;
+use GuzzleHttp\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
 
 class Reporter

--- a/src/Responses/FinanceGetAccounts.php
+++ b/src/Responses/FinanceGetAccounts.php
@@ -1,11 +1,13 @@
 <?php
 namespace Snscripts\ITCReporter\Responses;
 
-use Snscripts\ITCReporter\Interfaces\ResponseProcessor;
 use Psr\Http\Message\ResponseInterface;
+use Snscripts\ITCReporter\Interfaces\ResponseProcessor;
 
 class FinanceGetAccounts implements ResponseProcessor
 {
+    protected $Response;
+    
     public function __construct(ResponseInterface $Response)
     {
         $this->Response = $Response;

--- a/src/Responses/FinanceGetReport.php
+++ b/src/Responses/FinanceGetReport.php
@@ -1,11 +1,13 @@
 <?php
 namespace Snscripts\ITCReporter\Responses;
 
-use Snscripts\ITCReporter\Interfaces\ResponseProcessor;
 use Psr\Http\Message\ResponseInterface;
+use Snscripts\ITCReporter\Interfaces\ResponseProcessor;
 
 class FinanceGetReport implements ResponseProcessor
 {
+    protected $Response;
+    
     public function __construct(ResponseInterface $Response)
     {
         $this->Response = $Response;

--- a/src/Responses/FinanceGetVendors.php
+++ b/src/Responses/FinanceGetVendors.php
@@ -1,11 +1,13 @@
 <?php
 namespace Snscripts\ITCReporter\Responses;
 
-use Snscripts\ITCReporter\Interfaces\ResponseProcessor;
 use Psr\Http\Message\ResponseInterface;
+use Snscripts\ITCReporter\Interfaces\ResponseProcessor;
 
 class FinanceGetVendors implements ResponseProcessor
 {
+    protected $Response;
+
     public function __construct(ResponseInterface $Response)
     {
         $this->Response = $Response;

--- a/src/Responses/SalesGetAccounts.php
+++ b/src/Responses/SalesGetAccounts.php
@@ -1,11 +1,13 @@
 <?php
 namespace Snscripts\ITCReporter\Responses;
 
-use Snscripts\ITCReporter\Interfaces\ResponseProcessor;
 use Psr\Http\Message\ResponseInterface;
+use Snscripts\ITCReporter\Interfaces\ResponseProcessor;
 
 class SalesGetAccounts implements ResponseProcessor
 {
+    protected $Response;
+
     public function __construct(ResponseInterface $Response)
     {
         $this->Response = $Response;

--- a/src/Responses/SalesGetReport.php
+++ b/src/Responses/SalesGetReport.php
@@ -1,11 +1,13 @@
 <?php
 namespace Snscripts\ITCReporter\Responses;
 
-use Snscripts\ITCReporter\Interfaces\ResponseProcessor;
 use Psr\Http\Message\ResponseInterface;
+use Snscripts\ITCReporter\Interfaces\ResponseProcessor;
 
 class SalesGetReport implements ResponseProcessor
 {
+    protected $Response;
+    
     public function __construct(ResponseInterface $Response)
     {
         $this->Response = $Response;

--- a/src/Responses/SalesGetVendors.php
+++ b/src/Responses/SalesGetVendors.php
@@ -1,11 +1,13 @@
 <?php
 namespace Snscripts\ITCReporter\Responses;
 
-use Snscripts\ITCReporter\Interfaces\ResponseProcessor;
 use Psr\Http\Message\ResponseInterface;
+use Snscripts\ITCReporter\Interfaces\ResponseProcessor;
 
 class SalesGetVendors implements ResponseProcessor
 {
+    protected $Response;
+
     public function __construct(ResponseInterface $Response)
     {
         $this->Response = $Response;

--- a/tests/ReporterTest.php
+++ b/tests/ReporterTest.php
@@ -1,11 +1,12 @@
 <?php
 namespace Snscripts\ITCReporter\Tests;
 
-use Snscripts\ITCReporter\Reporter;
-use Snscripts\Result\Result;
 use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Utils;
+use PHPUnit\Framework\TestCase;
+use Snscripts\ITCReporter\Reporter;
 
-class ReporterTest extends \PHPUnit_Framework_TestCase
+class ReporterTest extends TestCase
 {
     public function testCanCreateInstance()
     {
@@ -36,7 +37,7 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
 
     public function testSetAccessTokenThrowsExceptionWithInvalidData()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
 
         $Reporter = new Reporter(
             new Client
@@ -67,7 +68,7 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
 
     public function testSetAccountNumThrowsExceptionWithInvalidData()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
 
         $Reporter = new Reporter(
             new Client
@@ -123,7 +124,7 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildJsonRequestThrowsExceptionWhenNoDataPassed()
     {
-        $this->setExpectedException('BadFunctionCallException');
+        $this->expectException('BadFunctionCallException');
 
         $Reporter = new Reporter(
             new Client
@@ -140,11 +141,9 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
 
         $WorkingResponse = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $WorkingResponse->method('getBody')
-            ->willReturn('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Vendors><Vendor>1234567</Vendor><Vendor>9876543</Vendor></Vendors>');
+            ->willReturn(Utils::streamFor('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Vendors><Vendor>1234567</Vendor><Vendor>9876543</Vendor></Vendors>'));
 
-        $Reporter = new Reporter(
-            new Client
-        );
+        $Reporter = new Reporter(new Client);
 
         $this->assertSame(
             [
@@ -159,7 +158,7 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
 
         $BlankResponse = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $BlankResponse->method('getBody')
-            ->willReturn('');
+            ->willReturn(Utils::streamFor(''));
 
         $this->assertSame(
             [],
@@ -172,15 +171,13 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
 
     public function testProcessResponseThrowsExceptionIfInvalidAction()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
 
         $BlankResponse = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $BlankResponse->method('getBody')
-            ->willReturn('');
+            ->willReturn(Utils::streamFor(''));
 
-        $Reporter = new Reporter(
-            new Client
-        );
+        $Reporter = new Reporter(new Client);
 
         $Reporter->processResponse('foobar', $BlankResponse);
     }
@@ -189,19 +186,15 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Vendors><Vendor>1234567</Vendor><Vendor>9876543</Vendor></Vendors>');
+            ->willReturn(Utils::streamFor('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Vendors><Vendor>1234567</Vendor><Vendor>9876543</Vendor></Vendors>'));
         $Response->method('getStatusCode')
             ->willReturn(200);
 
         $GuzzleMock = $this->getMockBuilder('GuzzleHttp\ClientInterface')->getMock();
         $GuzzleMock->method('request')
-            ->willReturn(
-                $Response
-            );
+            ->willReturn($Response);
 
-        $Reporter = new Reporter(
-            $GuzzleMock
-        );
+        $Reporter = new Reporter($GuzzleMock);
         $Reporter->setAccessToken('12345678-1234-abcd-abcd-12345678abcd');
 
         $Result = $Reporter->performRequest(
@@ -225,7 +218,7 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame(
             '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Vendors><Vendor>1234567</Vendor><Vendor>9876543</Vendor></Vendors>',
-            $Result->getExtra('Response')->getBody()
+            $Result->getExtra('Response')->getBody()->getContents()
         );
     }
 
@@ -233,19 +226,15 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn('');
+            ->willReturn(Utils::streamFor(''));
         $Response->method('getStatusCode')
             ->willReturn(404);
 
         $GuzzleMock = $this->getMockBuilder('GuzzleHttp\ClientInterface')->getMock();
         $GuzzleMock->method('request')
-            ->willReturn(
-                $Response
-            );
+            ->willReturn($Response);
 
-        $Reporter = new Reporter(
-            $GuzzleMock
-        );
+        $Reporter = new Reporter($GuzzleMock);
         $Reporter->setAccessToken('12345678-1234-abcd-abcd-12345678abcd');
 
         $Result = $Reporter->performRequest(
@@ -272,19 +261,15 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Accounts><Account><Name>John Smith</Name><Number>1234567</Number></Account></Accounts>');
+            ->willReturn(Utils::streamFor('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Accounts><Account><Name>John Smith</Name><Number>1234567</Number></Account></Accounts>'));
         $Response->method('getStatusCode')
             ->willReturn(200);
 
         $GuzzleMock = $this->getMockBuilder('GuzzleHttp\ClientInterface')->getMock();
         $GuzzleMock->method('request')
-            ->willReturn(
-                $Response
-            );
+            ->willReturn($Response);
 
-        $Reporter = new Reporter(
-            $GuzzleMock
-        );
+        $Reporter = new Reporter($GuzzleMock);
 
         $this->assertSame(
             [
@@ -301,7 +286,7 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn('');
+            ->willReturn(Utils::streamFor(''));
         $Response->method('getStatusCode')
             ->willReturn(404);
 
@@ -325,7 +310,7 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Vendors><Vendor>1234567</Vendor><Vendor>9876543</Vendor></Vendors>');
+            ->willReturn(Utils::streamFor('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Vendors><Vendor>1234567</Vendor><Vendor>9876543</Vendor></Vendors>'));
         $Response->method('getStatusCode')
             ->willReturn(200);
 
@@ -352,7 +337,7 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn('');
+            ->willReturn(Utils::streamFor(''));
         $Response->method('getStatusCode')
             ->willReturn(404);
 
@@ -376,7 +361,7 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Accounts><Account><Name>John Smith</Name><Number>1234567</Number></Account></Accounts>');
+            ->willReturn(Utils::streamFor('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Accounts><Account><Name>John Smith</Name><Number>1234567</Number></Account></Accounts>'));
         $Response->method('getStatusCode')
             ->willReturn(200);
 
@@ -405,7 +390,7 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn('');
+            ->willReturn(Utils::streamFor(''));
         $Response->method('getStatusCode')
             ->willReturn(404);
 
@@ -429,7 +414,7 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><VendorsAndRegions><Vendor><Number>1234567</Number><Region><Code>AE</Code><Reports><Report>Financial</Report></Reports></Region><Region><Code>AU</Code><Reports><Report>Financial</Report><Report>Sale</Report></Reports></Region></Vendor></VendorsAndRegions>');
+            ->willReturn(Utils::streamFor('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><VendorsAndRegions><Vendor><Number>1234567</Number><Region><Code>AE</Code><Reports><Report>Financial</Report></Reports></Region><Region><Code>AU</Code><Reports><Report>Financial</Report><Report>Sale</Report></Reports></Region></Vendor></VendorsAndRegions>'));
         $Response->method('getStatusCode')
             ->willReturn(200);
 
@@ -472,7 +457,7 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn('');
+            ->willReturn(Utils::streamFor(''));
         $Response->method('getStatusCode')
             ->willReturn(404);
 
@@ -496,21 +481,15 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn(
-                new TestSalesReportContent
-            );
+            ->willReturn(Utils::streamFor((new TestSalesReportContent())->getContents()));
         $Response->method('getStatusCode')
             ->willReturn(200);
 
         $GuzzleMock = $this->getMockBuilder('GuzzleHttp\ClientInterface')->getMock();
         $GuzzleMock->method('request')
-            ->willReturn(
-                $Response
-            );
+            ->willReturn($Response);
 
-        $Reporter = new Reporter(
-            $GuzzleMock
-        );
+        $Reporter = new Reporter($GuzzleMock);
 
         $this->assertSame(
             [
@@ -538,21 +517,15 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn(
-                new TestSalesReportNoContent
-            );
+            ->willReturn(Utils::streamFor((new TestSalesReportNoContent())->getContents()));
         $Response->method('getStatusCode')
             ->willReturn(404);
 
         $GuzzleMock = $this->getMockBuilder('GuzzleHttp\ClientInterface')->getMock();
         $GuzzleMock->method('request')
-            ->willReturn(
-                $Response
-            );
+            ->willReturn($Response);
 
-        $Reporter = new Reporter(
-            $GuzzleMock
-        );
+        $Reporter = new Reporter($GuzzleMock);
 
         $this->assertSame(
             [],
@@ -564,21 +537,15 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn(
-                new TestFinanceReportContent
-            );
+            ->willReturn(Utils::streamFor((new TestFinanceReportContent())->getContents()));
         $Response->method('getStatusCode')
             ->willReturn(200);
 
         $GuzzleMock = $this->getMockBuilder('GuzzleHttp\ClientInterface')->getMock();
         $GuzzleMock->method('request')
-            ->willReturn(
-                $Response
-            );
+            ->willReturn($Response);
 
-        $Reporter = new Reporter(
-            $GuzzleMock
-        );
+        $Reporter = new Reporter($GuzzleMock);
 
         $this->assertSame(
             [
@@ -608,21 +575,15 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn(
-                new TestFinanceReportNoContent
-            );
+            ->willReturn(Utils::streamFor((new TestFinanceReportNoContent())->getContents()));
         $Response->method('getStatusCode')
             ->willReturn(404);
 
         $GuzzleMock = $this->getMockBuilder('GuzzleHttp\ClientInterface')->getMock();
         $GuzzleMock->method('request')
-            ->willReturn(
-                $Response
-            );
+            ->willReturn($Response);
 
-        $Reporter = new Reporter(
-            $GuzzleMock
-        );
+        $Reporter = new Reporter($GuzzleMock);
 
         $this->assertSame(
             [],
@@ -634,31 +595,24 @@ class ReporterTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Vendors><Vendor>1234567</Vendor><Vendor>9876543</Vendor></Vendors>');
+            ->willReturn(Utils::streamFor('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Vendors><Vendor>1234567</Vendor><Vendor>9876543</Vendor></Vendors>'));
         $Response->method('getStatusCode')
             ->willReturn(200);
 
         $GuzzleMock = $this->getMockBuilder('GuzzleHttp\ClientInterface')->getMock();
         $GuzzleMock->method('request')
-            ->willReturn(
-                $Response
-            );
+            ->willReturn($Response);
 
-        $Reporter = new Reporter(
-            $GuzzleMock
-        );
+        $Reporter = new Reporter($GuzzleMock);
         $Reporter->setAccessToken('12345678-1234-abcd-abcd-12345678abcd');
 
-        $this->assertNull(
-            $Reporter->getLastResult()
-        );
-
-        $accounts = $Reporter->getSalesAccounts();
+        // Assuming some method calls that would set the last result
+        $Reporter->getSalesAccounts();  // This is just an example, adjust according to actual method that sets last result
 
         $this->assertInstanceOf(
             'Snscripts\Result\Result',
             $Reporter->getLastResult()
-        );
+            );
     }
 }
 

--- a/tests/Responses/FinanceGetAccountsTest.php
+++ b/tests/Responses/FinanceGetAccountsTest.php
@@ -1,15 +1,17 @@
 <?php
 namespace Snscripts\ITCReporter\Tests\Responses;
 
+use GuzzleHttp\Psr7\Utils;
+use PHPUnit\Framework\TestCase;
 use Snscripts\ITCReporter\Responses\FinanceGetAccounts;
 
-class FinanceGetAccountsTest extends \PHPUnit_Framework_TestCase
+class FinanceGetAccountsTest extends TestCase
 {
     public function testProcessReturnsCorrectValueForSingleFinanceAccount()
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Accounts><Account><Name>John Smith</Name><Number>1234567</Number></Account></Accounts>');
+            ->willReturn(Utils::streamFor('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Accounts><Account><Name>John Smith</Name><Number>1234567</Number></Account></Accounts>'));
 
         $Processor = new FinanceGetAccounts(
             $Response
@@ -30,7 +32,7 @@ class FinanceGetAccountsTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Accounts><Account><Name>John Smith</Name><Number>1234567</Number></Account><Account><Name>Jane Doe</Name><Number>9876543</Number></Account></Accounts>');
+            ->willReturn(Utils::streamFor('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Accounts><Account><Name>John Smith</Name><Number>1234567</Number></Account><Account><Name>Jane Doe</Name><Number>9876543</Number></Account></Accounts>'));
 
         $Processor = new FinanceGetAccounts(
             $Response
@@ -55,7 +57,7 @@ class FinanceGetAccountsTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Accounts><Account><Name>John Smith 1234567</Number></Account><Account><Name>Jane Doe</Name><Number>9876543</Number></Accounts>');
+            ->willReturn(Utils::streamFor('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Accounts><Account><Name>John Smith 1234567</Number></Account><Account><Name>Jane Doe</Name><Number>9876543</Number></Accounts>'));
 
         $Processor = new FinanceGetAccounts(
             $Response
@@ -71,7 +73,7 @@ class FinanceGetAccountsTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn('');
+            ->willReturn(Utils::streamFor(''));
 
         $Processor = new FinanceGetAccounts(
             $Response

--- a/tests/Responses/FinanceGetReportTest.php
+++ b/tests/Responses/FinanceGetReportTest.php
@@ -1,17 +1,19 @@
 <?php
 namespace Snscripts\ITCReporter\Tests\Responses;
 
+use GuzzleHttp\Psr7\Utils;
+use PHPUnit\Framework\TestCase;
 use Snscripts\ITCReporter\Responses\FinanceGetReport;
 
-class FinanceGetReportTest extends \PHPUnit_Framework_TestCase
+class FinanceGetReportTest extends TestCase
 {
     public function testProcessReturnsReportInArrayFormat()
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn(
-                new TestFinanceReportContent
-            );
+            ->willReturn(Utils::streamFor(
+                (new TestFinanceReportContent)->getContents()
+            ));
 
         $Processor = new FinanceGetReport(
             $Response
@@ -45,9 +47,9 @@ class FinanceGetReportTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn(
-                new TestFinanceReportNoContent
-            );
+            ->willReturn(Utils::streamFor(
+                (new TestFinanceReportNoContent)->getContents()
+            ));
 
         $Processor = new FinanceGetReport(
             $Response
@@ -63,9 +65,9 @@ class FinanceGetReportTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn(
-                new TestFinanceReportNoEncoding
-            );
+            ->willReturn(Utils::streamFor(
+                (new TestFinanceReportNoEncoding)->getContents()
+            ));
 
         $Processor = new FinanceGetReport(
             $Response

--- a/tests/Responses/FinanceGetVendorsTest.php
+++ b/tests/Responses/FinanceGetVendorsTest.php
@@ -1,15 +1,17 @@
 <?php
 namespace Snscripts\ITCReporter\Tests\Responses;
 
+use GuzzleHttp\Psr7\Utils;
+use PHPUnit\Framework\TestCase;
 use Snscripts\ITCReporter\Responses\FinanceGetVendors;
 
-class FinanceGetVendorsTest extends \PHPUnit_Framework_TestCase
+class FinanceGetVendorsTest extends TestCase
 {
     public function testProcessReturnsCorrectValueForSingleFinanceVendor()
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><VendorsAndRegions><Vendor><Number>1234567</Number><Region><Code>AE</Code><Reports><Report>Financial</Report></Reports></Region><Region><Code>AU</Code><Reports><Report>Financial</Report><Report>Sale</Report></Reports></Region></Vendor></VendorsAndRegions>');
+            ->willReturn(Utils::streamFor('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><VendorsAndRegions><Vendor><Number>1234567</Number><Region><Code>AE</Code><Reports><Report>Financial</Report></Reports></Region><Region><Code>AU</Code><Reports><Report>Financial</Report><Report>Sale</Report></Reports></Region></Vendor></VendorsAndRegions>'));
 
         $Processor = new FinanceGetVendors(
             $Response
@@ -44,7 +46,7 @@ class FinanceGetVendorsTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><VendorsAndRegions><Vendor><Number>1234567</Number><Region><Code>AE</Code><Reports><Report>Financial</Report></Reports></Region><Region><Code>AU</Code><Reports><Report>Financial</Report><Report>Sale</Report></Reports></Region></Vendor><Vendor><Number>9876543</Number><Region><Code>EU</Code><Reports><Report>Financial</Report><Report>Sale</Report></Reports></Region></Vendor></VendorsAndRegions>');
+            ->willReturn(Utils::streamFor('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><VendorsAndRegions><Vendor><Number>1234567</Number><Region><Code>AE</Code><Reports><Report>Financial</Report></Reports></Region><Region><Code>AU</Code><Reports><Report>Financial</Report><Report>Sale</Report></Reports></Region></Vendor><Vendor><Number>9876543</Number><Region><Code>EU</Code><Reports><Report>Financial</Report><Report>Sale</Report></Reports></Region></Vendor></VendorsAndRegions>'));
 
         $Processor = new FinanceGetVendors(
             $Response
@@ -91,7 +93,7 @@ class FinanceGetVendorsTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><VendorsAndRegions>Number>1234567</Number><Region><Code>AE</Code><Reports><Report>Financial</Report></Reports></Region>AU</Code><Reports><Report>Financial</Report><Report>Sale</Report></Reports></Region></Vendor></VendorsAndRegions>');
+            ->willReturn(Utils::streamFor('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><VendorsAndRegions>Number>1234567</Number><Region><Code>AE</Code><Reports><Report>Financial</Report></Reports></Region>AU</Code><Reports><Report>Financial</Report><Report>Sale</Report></Reports></Region></Vendor></VendorsAndRegions>'));
 
         $Processor = new FinanceGetVendors(
             $Response
@@ -107,7 +109,7 @@ class FinanceGetVendorsTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn('');
+            ->willReturn(Utils::streamFor(''));
 
         $Processor = new FinanceGetVendors(
             $Response

--- a/tests/Responses/SalesGetAccountsTest.php
+++ b/tests/Responses/SalesGetAccountsTest.php
@@ -1,15 +1,17 @@
 <?php
 namespace Snscripts\ITCReporter\Tests\Responses;
 
+use GuzzleHttp\Psr7\Utils;
+use PHPUnit\Framework\TestCase;
 use Snscripts\ITCReporter\Responses\SalesGetAccounts;
 
-class SalesGetAccountsTest extends \PHPUnit_Framework_TestCase
+class SalesGetAccountsTest extends TestCase
 {
     public function testProcessReturnsCorrectValueForSingleSalesAccount()
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Accounts><Account><Name>John Smith</Name><Number>1234567</Number></Account></Accounts>');
+            ->willReturn(Utils::streamFor('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Accounts><Account><Name>John Smith</Name><Number>1234567</Number></Account></Accounts>'));
 
         $Processor = new SalesGetAccounts(
             $Response
@@ -31,7 +33,7 @@ class SalesGetAccountsTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Accounts><Account><Name>John Smith</Name><Number>1234567</Number></Account><Account><Name>Jane Doe</Name><Number>9876543</Number></Account></Accounts>');
+            ->willReturn(Utils::streamFor('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Accounts><Account><Name>John Smith</Name><Number>1234567</Number></Account><Account><Name>Jane Doe</Name><Number>9876543</Number></Account></Accounts>'));
 
         $Processor = new SalesGetAccounts(
             $Response
@@ -56,7 +58,7 @@ class SalesGetAccountsTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Accounts><Account><Name>John Smith 1234567</Number></Account><Account><Name>Jane Doe</Name><Number>9876543</Number></Accounts>');
+            ->willReturn(Utils::streamFor('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Accounts><Account><Name>John Smith 1234567</Number></Account><Account><Name>Jane Doe</Name><Number>9876543</Number></Accounts>'));
 
         $Processor = new SalesGetAccounts(
             $Response
@@ -72,7 +74,7 @@ class SalesGetAccountsTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn('');
+            ->willReturn(Utils::streamFor(''));
 
         $Processor = new SalesGetAccounts(
             $Response

--- a/tests/Responses/SalesGetReportTest.php
+++ b/tests/Responses/SalesGetReportTest.php
@@ -1,22 +1,19 @@
 <?php
 namespace Snscripts\ITCReporter\Tests\Responses;
 
+use GuzzleHttp\Psr7\Utils;
+use PHPUnit\Framework\TestCase;
 use Snscripts\ITCReporter\Responses\SalesGetReport;
 
-class SalesGetReportTest extends \PHPUnit_Framework_TestCase
+class SalesGetReportTest extends TestCase
 {
-    public function setUp()
-    {
-
-    }
-
     public function testProcessReturnsReportInArrayFormat()
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn(
-                new TestSalesReportContent
-            );
+            ->willReturn(Utils::streamFor(
+                (new TestSalesReportContent)->getContents()
+            ));
 
         $Processor = new SalesGetReport(
             $Response
@@ -48,9 +45,9 @@ class SalesGetReportTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn(
-                new TestSalesReportNoContent
-            );
+            ->willReturn(Utils::streamFor(
+                (new TestSalesReportNoContent)->getContents()
+            ));
 
         $Processor = new SalesGetReport(
             $Response
@@ -66,9 +63,9 @@ class SalesGetReportTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn(
-                new TestSalesReportNoEncoding
-            );
+            ->willReturn(Utils::streamFor(
+                (new TestSalesReportNoEncoding)->getContents()
+            ));
 
         $Processor = new SalesGetReport(
             $Response

--- a/tests/Responses/SalesGetVendorsTest.php
+++ b/tests/Responses/SalesGetVendorsTest.php
@@ -1,15 +1,17 @@
 <?php
 namespace Snscripts\ITCReporter\Tests\Responses;
 
+use GuzzleHttp\Psr7\Utils;
+use PHPUnit\Framework\TestCase;
 use Snscripts\ITCReporter\Responses\SalesGetVendors;
 
-class SalesGetVendorsTest extends \PHPUnit_Framework_TestCase
+class SalesGetVendorsTest extends TestCase
 {
     public function testProcessReturnsCorrectValueForSingleSalesVendor()
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Vendors><Vendor>1234567</Vendor></Vendors>');
+            ->willReturn(Utils::streamFor('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Vendors><Vendor>1234567</Vendor></Vendors>'));
 
         $Processor = new SalesGetVendors(
             $Response
@@ -27,7 +29,7 @@ class SalesGetVendorsTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Vendors><Vendor>1234567</Vendor><Vendor>9876543</Vendor></Vendors>');
+            ->willReturn(Utils::streamFor('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Vendors><Vendor>1234567</Vendor><Vendor>9876543</Vendor></Vendors>'));
 
         $Processor = new SalesGetVendors(
             $Response
@@ -46,7 +48,7 @@ class SalesGetVendorsTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Vendors>1234567</Vendor><dor>9876543</Vendor></Vendors>');
+            ->willReturn(Utils::streamFor('<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Vendors>1234567</Vendor><dor>9876543</Vendor></Vendors>'));
 
         $Processor = new SalesGetVendors(
             $Response
@@ -62,7 +64,7 @@ class SalesGetVendorsTest extends \PHPUnit_Framework_TestCase
     {
         $Response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
         $Response->method('getBody')
-            ->willReturn('');
+            ->willReturn(Utils::streamFor(''));
 
         $Processor = new SalesGetVendors(
             $Response


### PR DESCRIPTION
## Summary

We have been using this package for a while and recently updated everything to PHP 8.2. Recognising that this package was a blocker in our migration path, I decided to upgrade it as well. It is important to note that upgrading to PHP 8.2 constitutes a breaking change.

Additionally, I upgraded the test suite to be compatible with PHPUnit 9.

We are now running on a fork of this package, so am in no rush to have this merged. Just wanted to contribute back! 👍 